### PR TITLE
fixed hooks not installing on npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "types.isaiahcreati.com",
   "scripts": {
-    "test": "tsc --noEmit --pretty --target es5"
+    "test": "tsc --noEmit --pretty --target es5",
+    "prepare": "husky install"
   },
   "devDependencies": {
     "husky": "^8.0.1",


### PR DESCRIPTION
Fixes issue where the typecheck pre commit hook won't install on first package install. If you haven't already, run `npm run prepare` and it will do a type check before you make a commit on your local install.